### PR TITLE
Fix Typo in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ API_MG_DB_PRODUCTION_CONFIG=''               # Additional production settings
 # API Keys for LLM Providers
 API_LLM_PROVIDER_MODEL="auto"
 API_OPENAI_FORCE_BASE_URL=""
-API_OPEN_AI_APIKEY=                          # OpenAI API key
+API_OPEN_AI_API_KEY=                         # OpenAI API key
 API_GOOGLE_AI_API_KEY=                       # Google AI API key
 API_ANTHROPIC_API_KEY=                       # Anthropic API key
 API_NOVITA_AI_API_KEY=                       # Novita AI API key


### PR DESCRIPTION
Fixed typo in API_OPEN_AI_API_KEY env