### PR TITLE
fix: docker images to use full names

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,7 @@ services:
     restart: unless-stopped
 
   db_kodus_postgres:
-    image: pgvector/pgvector:pg16
+    image: docker.io/pgvector/pgvector:pg16
     container_name: db_kodus_postgres
     ports:
       - "5432"
@@ -151,7 +151,7 @@ services:
       - kodus-backend-services
 
   db_kodus_mongodb:
-    image: mongo:8
+    image: docker.io/mongo:8
     container_name: db_kodus_mongodb
     ports:
       - "27017"

--- a/docker/pgvector/Dockerfile
+++ b/docker/pgvector/Dockerfile
@@ -1,3 +1,3 @@
-FROM pgvector/pgvector:pg16
+FROM docker.io/pgvector/pgvector:pg16
 
 COPY initdb.d/ /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Hey! I normally like to use podman instead of docker for security reasons, and be default this doesn't have anything in the registries. can we update the docker files to use the full registry name?

e.g
```
Error: short-name "pgvector/pgvector:pg16" did not resolve to an alias and no containers-registries.conf(5) was found
Error: short-name "mongo:8" did not resolve to an alias and no containers-registries.conf(5) was found
```

but using `docker.io/mongo:8` doesn't cause issues since it has a the full registry name.