### PR TITLE
feat: allow disabling ssl when in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,12 @@ API_JWT_REFRESH_EXPIRES_IN=7d                 # Refresh token expiration time
 # Use local containers for Postgres and MongoDB
 USE_LOCAL_DB=true
 
-# PostgreSQL Settings
 API_DATABASE_ENV="development"                # development, production, test
+# When API_DATABASE_ENV=production, you can set API_DATABASE_DISABLE_SSL='true' to disable SSL connection (e.g. for self-hosted docker deployments).
+# In production, it's recommended to use SSL and this defailts to 'false'
+API_DATABASE_DISABLE_SSL='false'
+
+# PostgreSQL Settings
 API_PG_DB_HOST=db_kodus_postgres              # PostgreSQL host
 API_PG_DB_PORT=5432                          # PostgreSQL port
 API_PG_DB_USERNAME=kodusdev                  # Database username


### PR DESCRIPTION
Currently it's not possible to run production mode with the self hosted docker containers using local DB's, we've split the requirement for having SSL and production in https://github.com/kodustech/kodus-ai/pull/695