### PR TITLE
fix: resolve self-hosted env var conflicts and networking issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,14 +129,16 @@ API_SERVICE_AST_URL=http://kodus-service-ast:3002  # URL of the AST service (int
 
 # KODUS_SERVICE_AST
 NODE_ENV=development
-API_NODE_ENV=development
-API_LOG_PRETTY=true
-API_LOG_LEVEL=info
+AST_NODE_ENV=development
+AST_LOG_PRETTY=true
+AST_LOG_LEVEL=info
 
 CONTAINER_NAME=kodus-service-ast
-API_PORT=3002
+AST_PORT=3002
 
-RABBIT_URL=amqp://user:pass@rabbitmq:5672/vhost
+DB_SSL=false                                     # Disable SSL for local Postgres (self-hosted)
+
+RABBIT_URL=amqp://kodus:kodus@rabbitmq:5672/kodus-ai
 RABBIT_RETRY_QUEUE=ast.jobs.retry.q
 RABBIT_RETRY_TTL_MS=60000
 RABBIT_PREFETCH=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     container_name: kodus-service-ast
     networks:
       - kodus-backend-services
+      - shared-network
     restart: unless-stopped
     env_file:
       - .env


### PR DESCRIPTION
- Rename AST vars (AST_PORT, AST_NODE_ENV, AST_LOG_LEVEL, AST_LOG_PRETTY) to avoid overriding main API config
- Add shared-network to kodus-service-ast for RabbitMQ connectivity
- Fix RABBIT_URL placeholder credentials to match actual RabbitMQ config
- Add DB_SSL=false for self-hosted Postgres without SSL