### PR TITLE
feat: add SANDBOX_PROVIDER env var for self-hosted sandbox configuration

### DIFF
--- a/.claude/skills/kodus-install/SKILL.md
+++ b/.claude/skills/kodus-install/SKILL.md
@@ -93,7 +93,8 @@ Also ask about optional review enhancers:
 | Variable | Description |
 |---|---|
 | `API_MORPHLLM_API_KEY` | MorphLLM API key — improves code review quality (optional) |
-| `API_E2B_KEY` | E2B API key — enables sandbox code execution during review (optional) |
+| `SANDBOX_PROVIDER` | Sandbox for cross-file context: `local` (recommended for self-hosted), `e2b` (cloud, needs `API_E2B_KEY`), `none` (disabled), `auto` (default — uses E2B if key set, otherwise disabled) |
+| `API_E2B_KEY` | E2B API key — only needed if `SANDBOX_PROVIDER=e2b` (optional) |
 
 ### 3.5 — Git Provider Webhooks
 

--- a/.env.example
+++ b/.env.example
@@ -78,10 +78,10 @@ API_LLM_PROVIDER_MODEL=""
 API_MORPHLLM_API_KEY=                         # MorphLLM API key (optional)
 
 # Sandbox provider for cross-file context and agent verification
-# Options: auto (default), e2b, local, none
-# - auto: uses E2B if API_E2B_KEY is set, otherwise disabled
-# - e2b: cloud sandbox via E2B (requires API_E2B_KEY)
+# Options: auto, e2b, local, none
 # - local: runs sandbox on the host machine (recommended for self-hosted)
+# - e2b: cloud sandbox via E2B (requires API_E2B_KEY)
+# - auto: uses E2B if API_E2B_KEY is set, otherwise disabled
 # - none: disables sandbox features
 SANDBOX_PROVIDER=local
 API_E2B_KEY=                                  # E2B sandbox API key (only needed if SANDBOX_PROVIDER=e2b)

--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,15 @@ API_LLM_PROVIDER_MODEL=""
 
 # Optional: external services that enhance code review quality
 API_MORPHLLM_API_KEY=                         # MorphLLM API key (optional)
-API_E2B_KEY=                                  # E2B sandbox API key (optional)
+
+# Sandbox provider for cross-file context and agent verification
+# Options: auto (default), e2b, local, none
+# - auto: uses E2B if API_E2B_KEY is set, otherwise disabled
+# - e2b: cloud sandbox via E2B (requires API_E2B_KEY)
+# - local: runs sandbox on the host machine (recommended for self-hosted)
+# - none: disables sandbox features
+SANDBOX_PROVIDER=local
+API_E2B_KEY=                                  # E2B sandbox API key (only needed if SANDBOX_PROVIDER=e2b)
 
 ## ----  CRON CONFIGURATION ----
 # Format: minute hour day_of_month month day_of_week


### PR DESCRIPTION
Adds the new SANDBOX_PROVIDER variable (defaulting to `local` for self-hosted) and updates the install skill documentation accordingly.