### PR TITLE
docs: link community-maintained Helm chart for Kubernetes installs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,18 @@ Then inside Claude Code, run:
 /kodus-install
 ```
 
+## Kubernetes / Helm
+
+If you'd rather run Kodus on Kubernetes than via Docker Compose, there's a community-maintained Helm chart at [ilanmotiei/kodus-helm](https://github.com/ilanmotiei/kodus-helm).
+
+```bash
+helm repo add kodus https://ilanmotiei.github.io/kodus-helm
+helm repo update
+helm install kodus kodus/kodus -n kodus --create-namespace -f my-values.yaml
+```
+
+The chart packages all six application services (api, worker, webhooks, web, optional mcp-manager, optional ast), bundled Postgres/MongoDB/RabbitMQ (with the `rabbitmq_delayed_message_exchange` plugin auto-installed), and helpers that hide the wiring around `NEXTAUTH_URL`, GitHub App credentials, and the LLM provider env-var quirks. Tested on AKS, GKE, EKS, DigitalOcean, and k3s. See the [chart README](https://github.com/ilanmotiei/kodus-helm#readme) for full configuration.
+
 ## External Databases or RabbitMQ
 
 If you already have PostgreSQL/MongoDB or RabbitMQ, you can disable the local containers and point Kodus to the external services.


### PR DESCRIPTION
## Summary

Adds a small "Kubernetes / Helm" section to the README pointing to a community-maintained Helm chart at [ilanmotiei/kodus-helm](https://github.com/ilanmotiei/kodus-helm) for users who'd rather run Kodus on a Kubernetes cluster than via Docker Compose.

The chart was built by reading this repo's `docker-compose.yml` and `.env.example` and following [the deploy docs](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm) closely so it matches the supported configuration. It is **not** affiliated with Kodus and the README change makes that clear.

## What's in the chart

- All six app services (`api`, `worker`, `webhooks`, `web`, optional `mcp-manager`, optional `ast`) as Deployments
- Bundled `pgvector/pgvector:pg16`, `mongo:8`, `rabbitmq:4.2.2-management` as StatefulSets — toggleable; flip to external services with one value
- Bundled RabbitMQ image gets `rabbitmq_delayed_message_exchange-4.2.0.ez` auto-installed via init-container (matches your `docker/rabbitmq/Dockerfile`)
- Init-containers wait for Postgres/Mongo/RabbitMQ before app pods boot, so users don't see CrashLoopBackOff during the first ~60s after install
- Helpers that hide the wiring users normally have to discover by reading source: `llm.{provider,model,apiKey,baseUrl}` (knows about the `API_OPEN_AI_API_KEY`-as-Anthropic-key path), `github.{oauth,app,pat}` (auto-derives `WEB_GITHUB_INSTALL_URL` from the App slug), `global.publicUrl.{web,webhooks}` (auto-fills `NEXTAUTH_URL` and the 5 Git provider webhook URLs)
- Auto-generated stable JWT/crypto secrets via Helm's `lookup` so values stay consistent across `helm upgrade`
- Multi-host Ingress with cert-manager TLS recipes documented in the chart README

Tested end-to-end on AKS, GKE, EKS, DigitalOcean, and k3s.

## What this PR is *not*

- Not adding a chart inside this repo. The chart lives in its own repository so this repo's docker-compose-focused tooling stays untouched.
- Not asking for endorsement. Happy to take "community" wording further if you'd prefer.

## Test plan

- [x] Link works (https://ilanmotiei.github.io/kodus-helm)
- [x] `helm repo add kodus https://ilanmotiei.github.io/kodus-helm && helm show chart kodus/kodus` returns the published 0.1.0 chart
- [x] README renders correctly on github.com — the new section sits between "Guided install with Claude Code" and "External Databases or RabbitMQ"

🤖 Generated with [Claude Code](https://claude.com/claude-code)