### PR TITLE
chore(env): sync from kodus-ai@main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,14 @@ API_NODE_ENV=development
 # (type: enum(development,production,test))
 API_DATABASE_ENV=development
 
-# When DATABASE_ENV=production, set this to 'true' to disable SSL (e.g. self-hosted docker).
+# When DATABASE_ENV=production, set this to 'true' to disable SSL.
+# Self-hosted ships a local Postgres container with no SSL, so the
+# installer default flips this to true. Cloud (AWS RDS, etc) keeps SSL on.
+# Covers ALL data sources (default + analytics) — individual API_PG_DB_SSL
+# only flipped the primary connection, which is why the api still crashed
+# on the analytics connection in the past.
 # (type: boolean)
-API_DATABASE_DISABLE_SSL=false
+API_DATABASE_DISABLE_SSL=true
 
 # Log verbosity. Cloud runs at info; self-hosted defaults to error to keep
 # disk usage and noise low for users without log aggregation.
@@ -27,6 +32,15 @@ API_LOG_LEVEL=error
 # Pretty-print logs (dev) vs JSON (prod).
 # (type: boolean)
 API_LOG_PRETTY=true
+
+# Self-hosted opt-in for `beta`-stage features in the catalog
+# (release/features.yaml). Default (unset / false) keeps the operator on
+# generally-available features only. Set to `true` to receive features
+# Kodus has shipped to cloud customers but not yet promoted to GA.
+# Cloud uses the per-org `release_track` column instead and ignores this
+# flag.
+# (type: boolean)
+BETA_FEATURES=false
 
 # Run TypeORM migrations on container boot (OLTP + analytics warehouse +
 # mcp-manager). Default true so a fresh install boots into a usable
@@ -112,7 +126,7 @@ API_PG_DB_PORT=5432
 API_PG_DB_USERNAME=kodusdev
 
 # (required, secret)
-API_PG_DB_PASSWORD=
+API_PG_DB_PASSWORD=123456
 
 API_PG_DB_DATABASE=kodus_db
 
@@ -136,7 +150,7 @@ API_MG_DB_PORT=27017
 API_MG_DB_USERNAME=kodusdev
 
 # (required, secret)
-API_MG_DB_PASSWORD=
+API_MG_DB_PASSWORD=123456
 
 API_MG_DB_DATABASE=kodus_db
 
@@ -162,6 +176,14 @@ RABBITMQ_HOSTNAME=rabbitmq
 API_RABBITMQ_URI=amqp://kodus:kodus@rabbitmq:5672/kodus-ai
 
 ## ----  WORKFLOW QUEUE TUNING  ----
+
+# Selects which workload this worker container handles. The kodus-worker
+# image refuses to boot without this — and the queues it owns (workflow.jobs.*)
+# are created on its first connection, so if the worker dies on boot the
+# api/webhooks fail with QueueBind 404 on every webhook event. Self-hosted
+# deployments only run the code-review role; analytics is a cloud worker.
+# (required, type: enum(code-review,analytics))
+WORKER_ROLE=code-review
 
 # (type: number)
 WORKFLOW_QUEUE_WORKER_PREFETCH=20
@@ -308,10 +330,40 @@ API_CRON_CHECK_IF_PR_SHOULD_BE_APPROVED="*/2 * * * *"
 # (type: cron)
 API_CRON_WEEKLY_RECAP="0 9 * * 5"
 
-## ----  EMAIL (RESEND — HTTPS://RESEND.COM)  ----
+## ----  EMAIL (RESEND — HTTPS://RESEND.COM / SMTP)  ----
+
+# Notifications email provider
+# (type: enum(resend,smtp))
+API_NOTIFICATION_EMAIL_PROVIDER=resend
+
+# Resend — Kodus-managed email sender.
+# (secret)
+RESEND_API_KEY=
 
 # (type: url)
 API_USER_INVITE_BASE_URL=http://localhost:3000
+
+# SMTP host
+API_SMTP_HOST=
+
+# SMTP port
+# (type: number)
+API_SMTP_PORT=587
+
+# SMTP secure mode
+# (type: boolean)
+API_SMTP_SECURE=
+
+# SMTP user
+API_SMTP_USER=
+
+# SMTP password
+# (secret)
+API_SMTP_PASS=
+
+# SMTP notifications sender email
+# (type: email)
+API_SMTP_FROM=noreply@notifications.kodus.io
 
 ## ----  WEB FRONTEND  ----
 
@@ -539,15 +591,6 @@ API_WORKER_DRAIN_TIMEOUT_MS=600000
 # published at https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md
 # (type: boolean)
 KODUS_TELEMETRY_DISABLED=false
-
-# Opt out of the self-hosted update banner. When false (default), the API
-# fetches the latest `selfhosted-*` release tag from
-# api.github.com/repos/kodustech/kodus-ai/releases (cached 24h in-memory)
-# and the web UI shows a top banner to organization owners when
-# RELEASE_VERSION is older. Set to "true" if your instance has no egress
-# to GitHub or you don't want the check. Cloud always skips this regardless.
-# (type: boolean)
-KODUS_UPDATE_CHECK_DISABLED=false
 
 ## ----  WEB — ADDITIONAL PAGES/SERVICES  ----
 

--- a/scripts/schema-vars.sh
+++ b/scripts/schema-vars.sh
@@ -8,6 +8,7 @@
 KODUS_REQUIRED_VARS=(
     API_PG_DB_PASSWORD
     API_MG_DB_PASSWORD
+    WORKER_ROLE
     API_JWT_SECRET
     API_JWT_REFRESH_SECRET
     API_CRYPTO_KEY
@@ -20,6 +21,8 @@ KODUS_REQUIRED_VARS=(
 # Format: VAR=method  (hex32 | base64-32 | base64url-32 | mirror:OTHER_VAR)
 # Derived from `kodus: autogen=...` in the schema.
 KODUS_AUTOGEN_SECRETS=(
+    "API_PG_DB_PASSWORD=hex32"
+    "API_MG_DB_PASSWORD=hex32"
     "API_JWT_SECRET=base64-32"
     "API_JWT_REFRESH_SECRET=base64-32"
     "API_CRYPTO_KEY=hex32"


### PR DESCRIPTION
Auto-generated from `kodus-ai/.env.schema` at tag `main` ([`2962bb2`](https://github.com/kodustech/kodus-ai/tree/2962bb229ede5280e0627b68450927a2dd9d0fba/.env.schema)).

Review the diff — added/removed vars and changed defaults reflect schema edits in kodus-ai.

Approve to keep `kodus-installer` in sync with this release cut.