### PR TITLE
chore(env): sync from kodus-ai@selfhosted-2.1.14

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,18 @@
 
 ## ----  ENVIRONMENT  ----
 
-# API node environment (drives feature toggles, logging, etc).
+# Runtime mode. In the kodus-ai dev tree this stays `development`
+# (verbose logs, host-only auth cookies, dev-seed endpoints enabled).
+# For self-hosted the installer ships `production` because every
+# self-hosted deployment IS a production environment: with
+# `development` the SSO handoff cookie is emitted without a Domain
+# attribute and without the Secure flag (auth.controller.ts:287,292 +
+# derive-sso-cookie-domain.ts:33), so the browser stores it host-only
+# on the API origin and the front-end on a different subdomain can't
+# read it — hard regression for any customer using SSO. Cloud envs
+# are templated by infra-as-code, not this file.
 # (type: enum(development,production,test))
-API_NODE_ENV=development
+API_NODE_ENV=production
 
 # Database environment selector — affects SSL defaults.
 # (type: enum(development,production,test))
@@ -239,8 +248,29 @@ API_OPEN_AI_API_KEY=
 # (type: url)
 API_OPENAI_FORCE_BASE_URL=
 
+# Comma-separated baseURL substrings trusted for native json_schema
+# structured output on BYOK openai_compatible providers. A capability
+# allowlist: when a BYOK baseURL contains one of these, the code review
+# agent sends response_format=json_schema instead of the slower
+# json_object fallback. Leave empty unless you run a non-vLLM but
+# schema-capable proxy.
+API_TRUST_JSON_SCHEMA_BASE_URLS=
+
 # Force a specific model. "auto" = router picks per task.
 API_LLM_PROVIDER_MODEL=auto
+
+# Override the temperature for every LLM call (env-mode self-hosted only).
+# Set this if `API_LLM_PROVIDER_MODEL` points at a reasoning/thinking
+# model whose API restricts temperature (Moonshot's `kimi-k2.6` and
+# `kimi-k2-thinking*` only accept temperature=1; OpenAI's o1 family is
+# similar). When unset/empty, Kodus auto-clamps a small list of known
+# reasoning models to 1 and falls through to each prompt's
+# `setTemperature()` for everything else. Consumed by
+# libs/code-review/.../env-llm-config.ts and surfaced in
+# get-llm-config-status so the dashboard can explain why every prompt
+# ignores its hard-coded temperature.
+# (type: number)
+API_LLM_TEMPERATURE_OVERRIDE=
 
 # MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM
 # to apply LLM-suggested code edits automatically and reliably (better than
@@ -420,6 +450,9 @@ WEB_TOKEN_DOCS_BITBUCKET=https://docs.kodus.io/how_to_use/en/code_review/general
 # (type: url)
 WEB_TOKEN_DOCS_AZUREREPOS=https://docs.kodus.io/how_to_use/en/code_review/general_config/azure_devops_pat
 
+# (type: url)
+WEB_TOKEN_DOCS_FORGEJO=
+
 ## ----  COCKPIT / ANALYTICS SERVICE — SELF-HOSTED ENTERPRISE  ----
 
 # Enables the MCP integration in kodus-ai (calls into the MCP Manager service).
@@ -429,8 +462,14 @@ API_MCP_SERVER_ENABLED=false
 
 # Address of the kodus-mcp-manager service (sibling container).
 # kodus-ai calls this URL to provision MCP servers per organization.
+# In docker-compose self-hosted installs, the worker and mcp-manager run
+# in sibling containers — `localhost` inside the worker resolves to the
+# worker itself, not to the mcp-manager, and pipeline stages that call
+# `MCPManagerService.getConnections()` 400 with ECONNREFUSED. Always use
+# the compose service name (`kodus-mcp-manager`) so the request reaches
+# the right container.
 # (type: url)
-API_KODUS_SERVICE_MCP_MANAGER=http://localhost:3101
+API_KODUS_SERVICE_MCP_MANAGER=http://kodus-mcp-manager:3101
 
 # Public URL where MCP clients (e.g. Cursor/Claude Desktop) connect to
 # consume MCP tools exposed by kodus-ai itself.


### PR DESCRIPTION
Auto-generated from `kodus-ai/.env.schema` at tag `selfhosted-2.1.14` ([`c159744`](https://github.com/kodustech/kodus-ai/tree/c15974442b835c04220754058235dc02972c8da2/.env.schema)).

Review the diff — added/removed vars and changed defaults reflect schema edits in kodus-ai.

Approve to keep `kodus-installer` in sync with this release cut.