### PR TITLE
fix(rabbitmq): use published kodus-rabbitmq image instead of local build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,9 +107,15 @@ services:
     restart: unless-stopped
 
   rabbitmq:
-    build:
-      context: ./docker/rabbitmq
-      dockerfile: Dockerfile
+    # Pre-built image bundling the rabbitmq_delayed_message_exchange plugin
+    # (required by Kodus workflow delayed retries — see kodus-ai issue #873).
+    # Published by kodus-ai .github/workflows/rabbitmq-build-push.yml: base
+    # digest-pinned, plugin/rabbitmqadmin SHA256-verified, Trivy-scanned, and
+    # it provisions both the kodus-ai and kodus-ast vhosts. Pinned to a fixed
+    # tag rather than :latest because this image tracks the RabbitMQ + plugin
+    # version, not the Kodus release. The local docker/rabbitmq/ build context
+    # is kept as a fallback but is no longer used.
+    image: ghcr.io/kodustech/kodus-rabbitmq:4.2.2-kodus
     container_name: rabbitmq-prod
     hostname: ${RABBITMQ_HOSTNAME:-rabbitmq}
     ports:


### PR DESCRIPTION
## What
Switch the `rabbitmq` service from a local `build:` of `docker/rabbitmq` to the pre-built, multi-arch image **`ghcr.io/kodustech/kodus-rabbitmq:4.2.2-kodus`**.

## Why
Resolves the self-hosted half of kodustech/kodus-ai#873 (RabbitMQ delayed plugin). The published image:
- bundles `rabbitmq_delayed_message_exchange` v4.2.0 (required by Kodus workflow delayed retries — services crash with `PRECONDITION_FAILED - unknown exchange type 'x-delayed-message'` without it)
- is base **digest-pinned** with **SHA256-verified** plugin/rabbitmqadmin downloads, **Trivy-scanned** in CI
- is **multi-arch** (amd64 + arm64)
- provisions **both** the `kodus-ai` and `kodus-ast` vhosts on boot

The previous local `docker/rabbitmq` build only created the `kodus-ai` vhost and used unverified `wget` downloads off a moving base tag.

## Notes
- Pinned to a fixed tag (not `:latest`) because the image tracks the RabbitMQ + plugin version, not the Kodus release.
- Same service name, `command`, and volume → fully compatible with the `USE_LOCAL_RABBITMQ` toggle in `install.sh`/`doctor.sh`.
- The local `docker/rabbitmq/` build context is kept as a fallback but is no longer used.
- Validated with `docker compose config` (image resolves, `command`/volume preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)