### PR TITLE
fix(compose): honor IMAGE_TAG so the release matrix actually tests the RC image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kodus-web:
-    image: ghcr.io/kodustech/kodus-ai-web:latest
+    image: ghcr.io/kodustech/kodus-ai-web:${IMAGE_TAG:-latest}
     container_name: kodus-web-prod
     ports:
       - "${WEB_PORT}:${WEB_PORT}"
@@ -14,7 +14,7 @@ services:
       - .env
 
   api:
-    image: ghcr.io/kodustech/kodus-ai-api:latest
+    image: ghcr.io/kodustech/kodus-ai-api:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: ${GLOBAL_API_CONTAINER_NAME:-kodus-api}
     volumes:
@@ -40,7 +40,7 @@ services:
       - rabbitmq
 
   worker:
-    image: ghcr.io/kodustech/kodus-ai-worker:latest
+    image: ghcr.io/kodustech/kodus-ai-worker:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: kodus-worker-prod
     volumes:
@@ -64,7 +64,7 @@ services:
       - rabbitmq
 
   webhooks:
-    image: ghcr.io/kodustech/kodus-ai-webhook:latest
+    image: ghcr.io/kodustech/kodus-ai-webhook:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: kodus-webhooks-prod
     volumes:
@@ -91,7 +91,7 @@ services:
       - rabbitmq
 
   kodus-mcp-manager:
-    image: ghcr.io/kodustech/kodus-mcp-manager:latest
+    image: ghcr.io/kodustech/kodus-mcp-manager:${IMAGE_TAG:-latest}
     platform: linux/amd64
     container_name: kodus-mcp-manager
     ports:


### PR DESCRIPTION
## Context

On the 2026-06-05 kodus-ai release run, the self-hosted matrix cell `github × license-paid` failed with 25+33 RBAC mismatches. Root cause: the droplet was running **2.1.15 (`:latest`)**, not the RC under test.

`tests/e2e/provisioning/self-hosted/vm.sh` writes `IMAGE_TAG=<rc-tag>` into `/opt/kodus-installer/.env`, but this compose file hardcoded `:latest` on all five kodus images — compose never read the variable. Consequence: **the release matrix has been validating the previous release instead of the RC, every week**, and `promote` ships an image the gate never ran. (It only surfaced now because this week's RBAC changes made main's tests diverge from 2.1.15 behavior.)

## Fix

`image: ghcr.io/kodustech/<svc>:${IMAGE_TAG:-latest}` on web/api/worker/webhooks/mcp-manager (rabbitmq stays pinned at its own version).

- Customer installs: no `.env` change needed — absent var resolves to `:latest`, identical behavior.
- E2E droplets: `IMAGE_TAG` from `.env` pins the exact RC.
- Bonus: the `upgrade` scenario's `IMAGE_TAG` sed (upgrade.sh) was silently a no-op — it becomes real with this change.

## Validation

```
$ docker compose config --quiet                       # no var → resolves, :latest
$ IMAGE_TAG=selfhosted-2.1.16-rc.67 docker compose config | grep image:
    image: ghcr.io/kodustech/kodus-ai-api:selfhosted-2.1.16-rc.67
    ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)