### PR TITLE
chore(env): sync from kodus-ai@selfhosted-2.1.16

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,12 +24,13 @@ API_NODE_ENV=production
 # (type: enum(development,production,test))
 API_DATABASE_ENV=development
 
-# When DATABASE_ENV=production, set this to 'true' to disable SSL.
-# Self-hosted ships a local Postgres container with no SSL, so the
-# installer default flips this to true. Cloud (AWS RDS, etc) keeps SSL on.
-# Covers ALL data sources (default + analytics) — individual API_PG_DB_SSL
-# only flipped the primary connection, which is why the api still crashed
-# on the analytics connection in the past.
+# Disable SSL on ALL Postgres connections (default + analytics warehouse).
+# Local docker dev and self-hosted both run a Postgres container with no
+# SSL, so the default is true. Cloud (AWS RDS, etc) requires SSL — its
+# deploy env MUST set this to false explicitly.
+# Covers ALL data sources — individual API_PG_DB_SSL only flipped the
+# primary connection, which is why the api still crashed on the analytics
+# connection (db_postgres is non-loopback, so SSL stayed on) in the past.
 # (type: boolean)
 API_DATABASE_DISABLE_SSL=true
 
@@ -77,7 +78,7 @@ USE_LOCAL_RABBITMQ=true
 
 ## ----  SERVER  ----
 
-GLOBAL_API_CONTAINER_NAME=kodus-api
+GLOBAL_API_CONTAINER_NAME=kodus_api
 
 API_HOST=0.0.0.0
 
@@ -189,8 +190,9 @@ API_RABBITMQ_URI=amqp://kodus:kodus@rabbitmq:5672/kodus-ai
 # Selects which workload this worker container handles. The kodus-worker
 # image refuses to boot without this — and the queues it owns (workflow.jobs.*)
 # are created on its first connection, so if the worker dies on boot the
-# api/webhooks fail with QueueBind 404 on every webhook event. Self-hosted
-# deployments only run the code-review role; analytics is a cloud worker.
+# api/webhooks fail with QueueBind 404 on every webhook event. Every
+# deployment runs code-review; analytics is a separate Cockpit worker when
+# that feature is enabled.
 # (required, type: enum(code-review,analytics))
 WORKER_ROLE=code-review
 
@@ -300,6 +302,21 @@ API_GITLAB_CODE_MANAGEMENT_WEBHOOK=
 # (type: url)
 GLOBAL_BITBUCKET_CODE_MANAGEMENT_WEBHOOK=
 
+# Minimum interval (ms) between Bitbucket API calls per worker instance.
+# In-memory rate gate to keep us under Bitbucket's per-minute throttle.
+# Note: this is per-replica — with N workers the effective rate is N×
+# whatever you set here. 400ms is safe for typical multi-replica setups;
+# raise it if a customer's Bitbucket instance throttles aggressively.
+# (type: number, opt-in: uncomment to enable)
+# BITBUCKET_RATE_GATE_MIN_INTERVAL_MS=400
+
+# How many times to retry a Bitbucket call that returns HTTP 429 (honouring
+# Retry-After) before giving up. Reviews legitimately burst past Bitbucket
+# Cloud's ~1000 req/hour ceiling; retrying keeps them alive instead of
+# failing the review. 4 attempts covers the worst observed throttle windows.
+# (type: number, opt-in: uncomment to enable)
+# BITBUCKET_RATE_GATE_429_MAX_RETRIES=4
+
 # (type: url)
 GLOBAL_AZURE_REPOS_CODE_MANAGEMENT_WEBHOOK=
 
@@ -359,6 +376,10 @@ API_CRON_CHECK_IF_PR_SHOULD_BE_APPROVED="*/2 * * * *"
 # Friday at 09:00 UTC — weekly recap email.
 # (type: cron)
 API_CRON_WEEKLY_RECAP="0 9 * * 5"
+
+# Every hour
+# (type: cron)
+API_CRON_SPEND_LIMIT_ALERT="0 * * * *"
 
 ## ----  EMAIL (RESEND — HTTPS://RESEND.COM / SMTP)  ----
 
@@ -623,13 +644,21 @@ API_WORKER_DRAIN_TIMEOUT_MS=600000
 
 # Opt out of the daily anonymous heartbeat sent to telemetry.kodus.io.
 # Cloud is unaffected — the cron skips when API_CLOUD_MODE=true regardless.
-# Self-hosted operators flip this to "true" to disable. The payload is
-# aggregated counters (active users, PRs reviewed, repos connected, etc.)
-# plus runtime metadata (Node version, OS, deployment). It never includes
-# emails, repo/branch/PR names, code, or any identifying data. Full schema
-# published at https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md
+# The heartbeat runs from the mandatory code-review worker, so community and
+# enterprise self-hosted installs are covered. Self-hosted operators flip this
+# to "true" to disable. The payload is aggregated counters (active users, PRs
+# reviewed, repos connected, etc.) plus runtime metadata (Node version, OS,
+# deployment). It never includes emails, repo/branch/PR names, code, or any
+# identifying data. Full schema published at
+# https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md
 # (type: boolean)
 KODUS_TELEMETRY_DISABLED=false
+
+# Optional receiver endpoint override for tests or controlled internal
+# deployments. Leave empty in production to use
+# https://telemetry.kodus.io/v1/heartbeat.
+# (type: url)
+KODUS_TELEMETRY_ENDPOINT=
 
 ## ----  WEB — ADDITIONAL PAGES/SERVICES  ----
 


### PR DESCRIPTION
Auto-generated from `kodus-ai/.env.schema` at tag `selfhosted-2.1.16` ([`999f3c6`](https://github.com/kodustech/kodus-ai/tree/999f3c6ca42df93dceb49d3da2300c997ea0f5a8/.env.schema)).

Review the diff — added/removed vars and changed defaults reflect schema edits in kodus-ai.

Approve to keep `kodus-installer` in sync with this release cut.