### PR TITLE
feat(compose): add optional analytics worker for self-hosted Cockpit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,41 @@ services:
       - db_kodus_mongodb
       - rabbitmq
 
+  # Analytics ingestion worker (Enterprise / Cockpit). Same image as `worker`,
+  # only WORKER_ROLE differs: this process runs the cockpit warehouse ingestion
+  # + PR classifier crons and writes the `analytics` Postgres schema. The main
+  # `worker` stays role=code-review and never touches analytics.
+  #
+  # Opt-in: gated behind the `analytics` compose profile so community installs
+  # don't pay for an idle worker. Enable with `COMPOSE_PROFILES=analytics`
+  # (and set the ANALYTICS_* block in .env). See docs → Analytics Worker.
+  worker-analytics:
+    image: ghcr.io/kodustech/kodus-ai-worker:${IMAGE_TAG:-latest}
+    platform: linux/amd64
+    container_name: kodus-worker-analytics
+    profiles:
+      - analytics
+    volumes:
+      - log_volume:/app/logs
+    logging:
+      options:
+        max-size: "200m"
+        max-file: "10"
+    environment:
+      - ENV=production
+      - NODE_ENV=production
+      - WORKER_ROLE=analytics
+    networks:
+      - shared-network
+      - kodus-backend-services
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      - db_kodus_postgres
+      - db_kodus_mongodb
+      - rabbitmq
+
   webhooks:
     image: ghcr.io/kodustech/kodus-ai-webhook:${IMAGE_TAG:-latest}
     platform: linux/amd64


### PR DESCRIPTION
## What
Adds an optional `worker-analytics` service (`WORKER_ROLE=analytics`) to the self-hosted compose, behind the `analytics` Compose profile.

## Why
The Cockpit ingestion crons only run under `WORKER_ROLE=analytics`, but the installer shipped a single `code-review` worker — so self-hosted Enterprise warehouses never populated and the cockpit stayed empty even with a valid license. This service is what keeps the analytics warehouse fresh.

Community installs are unchanged: the service is **off by default** (gated by the profile), so a normal `docker compose up` never starts it. Enable with `COMPOSE_PROFILES=analytics`.

## Note on env
`.env.example` is auto-generated from `kodus-ai/.env.schema`, so it's intentionally NOT hand-edited here. The `ANALYTICS_*` vars already have schema defaults and the warehouse host falls back to `API_PG_DB_*`, so the worker boots fine with no extra `.env` block. Operator guidance lives in the Analytics Worker deploy doc.

## Hotfix — ships together with
Companion PR (code fixes + e2e coverage + docs): kodustech/kodus-ai#1293
Both must land in the same release: without this PR the ingestion cron never runs; without the companion the warehouse migrations don't ship and the cockpit page is gated.

## Validated
Live on a self-hosted droplet (fixed images): enabling the profile brings up the `role=analytics` worker, which auto-ingests Mongo → warehouse on its cron with no manual backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
