### PR TITLE
fix(compose): run DB migrations only on the api (single-migrator)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,12 @@ services:
     environment:
       - ENV=production
       - NODE_ENV=production
+      # Only `api` runs DB migrations on boot — it runs the OLTP *and* the
+      # analytics-warehouse migrations from the shared prod-entrypoint. If
+      # worker/webhooks/worker-analytics also migrated concurrently they would
+      # race on CREATE TYPE (duplicate key pg_type_typname_nsp_index) and
+      # crash-loop the first boot. Override the .env default to false here.
+      - RUN_MIGRATIONS=false
     networks:
       - shared-network
       - kodus-backend-services
@@ -87,6 +93,8 @@ services:
       - ENV=production
       - NODE_ENV=production
       - WORKER_ROLE=analytics
+      # Migrations belong to `api` only — see the note on the `worker` service.
+      - RUN_MIGRATIONS=false
     networks:
       - shared-network
       - kodus-backend-services
@@ -114,6 +122,8 @@ services:
       - ENV=production
       - NODE_ENV=production
       - API_WEBHOOKS_PORT=${API_WEBHOOKS_PORT:-3332}
+      # Migrations belong to `api` only — see the note on the `worker` service.
+      - RUN_MIGRATIONS=false
     networks:
       - shared-network
       - kodus-backend-services


### PR DESCRIPTION
## Problem

`.env` ships `RUN_MIGRATIONS=true` and **every service inherits it via `env_file`**, so `api`, `worker`, `webhooks` and `worker-analytics` all run the shared `prod-entrypoint` migration block **concurrently** on boot. They race on `CREATE TYPE`:

```
duplicate key value violates unique constraint "pg_type_typname_nsp_index"
```

→ migration fails under `set -e` → container **crash-loops** (observed on a real droplet: api/webhooks RestartCount=2). And because the analytics-warehouse migration runs **after** OLTP in the same entrypoint, the warehouse is left uncreated during the churn window → `/cockpit/validate` **500** (the cockpit/analytics symptom customers hit).

## Fix

Override `RUN_MIGRATIONS=false` on **worker, worker-analytics, webhooks** via their per-service `environment:` (which takes precedence over `env_file`), leaving only **api** to migrate.

- The **api** runs **both** OLTP and the analytics-warehouse migrations in the same entrypoint, so analytics is still fully set up.
- The **analytics worker** only needs the schema to exist — it *ingests*, it doesn't migrate.
- **mcp-manager** keeps `RUN_MIGRATIONS=true`: it owns a *separate* schema via its own entrypoint and never touches OLTP/analytics, so no collision (this mirrors `docker-compose.dev.yml`, which already forces `RUN_MIGRATIONS=false` on mcp-manager for the same single-migrator reason).

## Verified

`docker compose --profile analytics config` resolves `RUN_MIGRATIONS`:

| service | RUN_MIGRATIONS |
|---|---|
| api | `true` |
| worker | `false` |
| worker-analytics | `false` |
| webhooks | `false` |
| mcp-manager | `true` (own schema) |

Two lines per service, no app-image change. Replaces the heavier kodus-ai advisory-lock approach (closed: kodus-ai#1298) — cloud already runs migrations out-of-band, so this single-migrator config is all that's needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)