### PR TITLE
chore(env): sync from kodus-ai@selfhosted-2.1.18

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # =============================================
 # Kodus self-hosted environment file
 # AUTO-GENERATED from kodus-ai/.env.schema. Do NOT edit by hand.
-# Run `yarn env:generate --apply` in kodus-ai after editing the schema.
+# Run `pnpm run env:generate --apply` in kodus-ai after editing the schema.
 # =============================================
 
 

--- a/scripts/schema-vars.sh
+++ b/scripts/schema-vars.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # AUTO-GENERATED from kodus-ai/.env.schema. Do NOT edit by hand.
 # Sourced by scripts/install.sh, scripts/doctor.sh, scripts/generate-secrets.sh
-# Run `yarn env:generate --apply --installer` in kodus-ai to regenerate.
+# Run `pnpm run env:generate --apply --installer` in kodus-ai to regenerate.
 
 # Vars the installer must see set before booting the stack.
 # Derived from `@required` in the schema (self-hosted audience).


### PR DESCRIPTION
Auto-generated from `kodus-ai/.env.schema` at tag `selfhosted-2.1.18` ([`9e941f4`](https://github.com/kodustech/kodus-ai/tree/9e941f4c5f3d89eb5bcf713fb901aef1eedec9ef/.env.schema)).

Review the diff — added/removed vars and changed defaults reflect schema edits in kodus-ai.

Approve to keep `kodus-installer` in sync with this release cut.